### PR TITLE
feat: pass authorization token through gateway

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,17 @@ const require = createRequire(import.meta.url);
 import config from "./config.js";
 
 const { ApolloServer } = require("apollo-server");
-const { ApolloGateway } = require("@apollo/gateway");
+const { ApolloGateway, RemoteGraphQLDataSource } = require("@apollo/gateway");
+
+class AuthenticatedDataSource extends RemoteGraphQLDataSource {
+  willSendRequest({ request, context }) {
+    // pass the authorization token from the context to underlying services
+    // as a header called "Authorization"
+    if (context.authorizationToken) {
+      request.http.headers.set('Authorization', context.authorizationToken);
+    }
+  }
+}
 
 async function main () {
   if (!config.SERVICES.length) {
@@ -14,12 +24,20 @@ async function main () {
   }
 
   const gateway = new ApolloGateway({
-    serviceList: config.SERVICES
+    serviceList: config.SERVICES,
+    buildService({ url }) {
+      return new AuthenticatedDataSource({ url });
+    },
+    debug: true
   });
 
   const server = new ApolloServer({
     gateway,
-    subscriptions: false
+    subscriptions: false,
+    context: ({ req }) => {
+      const authorizationToken = req.headers.authorization || null;
+      return { authorizationToken };
+    }
   });
 
   const { url } = await server.listen({ port: 2000 });


### PR DESCRIPTION
Resolves #14 
Impact: **major**
Type: **feature**

## Summary
Passes `Authorization` token through the gateway to allow authenticated requests via the gateway

## Testing
1. Spin up an API instance, and a Gateway instance
1. Make sure you have the `API` service listed in the Gateway `SERVICES` config in the `env`
1. Perform an authenticated action via the gateway (`:2000`): create / update a product, change shop settings, etc: anything that would require an authenticated user
1. See that it works
1. Perform the same action via the GQL API (`:3000`)
1. See that it works
