### PR TITLE
chore: automatic npm install setup workaround

### DIFF
--- a/.reaction/project-hooks/post-build
+++ b/.reaction/project-hooks/post-build
@@ -20,3 +20,7 @@ __root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 __root_name=$(basename "${__root_dir}")
 
 echo "${__root_name} post-build script invoked." 2>&1
+
+echo "Running 'npm install' in a Docker container to work around dependency issues." 2>&1
+cd "${__root_dir}"
+docker-compose run --rm gateway npm install


### PR DESCRIPTION
The project failed to setup correctly on the first try. The ideal solution would be for the project image to contain the deps or build them during the build step, but this is a quick solution that doesn't require deep understanding of the node image.

To use this, I added an entry to my Reaction platform's `config.local.mk`:

```
define SUBPROJECT_REPOS
# other projects...
git@github.com:/reactioncommerce/federated-gateway.git,federated-gateway,trunk
endef
```

And then I can start the project with platform. All setup and
`npm installing` runs automatically.

```
# from the platform directory
make init-federated-gateway
```

## Breaking changes
None.

## Testing
1. Add federated-gateway to the platform's `config.local.mk` file.  
```
define SUBPROJECT_REPOS
# other projects...
git@github.com:/reactioncommerce/federated-gateway.git,federated-gateway,trunk
endef
```
2. `cd <platform-directory>`
3. `make clean-federated-gateway`
4. `rm -R ./federated-gateway/node_modules` to remove existing node modules.
5. `make init-federated-gateway`